### PR TITLE
Implement drmkpi kthread.

### DIFF
--- a/drmkpi/drmkpi_kthread.c
+++ b/drmkpi/drmkpi_kthread.c
@@ -1,0 +1,131 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2021 Ruslan Bukin <br@bsdpad.com>
+ *
+ * This work was supported by Innovate UK project 105694, "Digital Security
+ * by Design (DSbD) Technology Platform Prototype".
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+__FBSDID("$FreeBSD$");
+
+#include <sys/proc.h>
+#include <sys/bus.h>
+#include <sys/interrupt.h>
+#include <sys/priority.h>
+
+#include <linux/kthread.h>
+
+#define	DRMKPI_SUSPEND_WAIT	2000000
+
+bool
+drmkpi_kthread_should_stop_task(struct thread *td)
+{
+
+	if (td->td_flags & TDF_KTH_SUSP)
+		return (true);
+
+	return (false);
+}
+
+bool
+drmkpi_kthread_should_stop(void)
+{
+	struct thread *td;
+
+	td = curthread;
+
+	return (drmkpi_kthread_should_stop_task(td));
+}
+
+int
+drmkpi_kthread_stop(struct thread *td)
+{
+	int error;
+
+	error = kthread_suspend(td, DRMKPI_SUSPEND_WAIT);
+
+	return (error);
+}
+
+int
+drmkpi_kthread_park(struct thread *td)
+{
+	int error;
+
+	error = kthread_suspend(td, DRMKPI_SUSPEND_WAIT);
+
+	return (error);
+}
+
+void
+drmkpi_kthread_parkme(void)
+{
+
+	kthread_suspend_check();
+}
+
+bool
+drmkpi_kthread_should_park(void)
+{
+	struct thread *td;
+
+	td = curthread;
+
+	return (drmkpi_kthread_should_stop_task(td));
+}
+
+void
+drmkpi_kthread_unpark(struct thread *td)
+{
+
+	kthread_resume(td);
+}
+
+struct thread *
+drmkpi_kthread_setup_and_run(struct thread *td)
+{
+
+	thread_lock(td);
+	/* make sure the scheduler priority is raised */
+	sched_prio(td, PI_SWI(SWI_NET));
+	/* put thread into run-queue */
+	sched_add(td, SRQ_BORING);
+
+	return (td);
+}
+
+void
+drmkpi_kthread_fn(void *arg)
+{
+	struct kthr_wrap *w;
+
+	w = arg;
+	w->func(w->arg);
+
+	free(w, M_DRMKMALLOC);
+
+	kthread_exit();
+}

--- a/drmkpi/include/linux/kthread.h
+++ b/drmkpi/include/linux/kthread.h
@@ -1,1 +1,80 @@
-/* Dummy file */
+/*-
+ * Copyright (c) 2010 Isilon Systems, Inc.
+ * Copyright (c) 2010 iX Systems, Inc.
+ * Copyright (c) 2010 Panasas, Inc.
+ * Copyright (c) 2013-2017 Mellanox Technologies, Ltd.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice unmodified, this list of conditions, and the following
+ *    disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * $FreeBSD$
+ */
+
+#ifndef	_LINUX_KTHREAD_H_
+#define	_LINUX_KTHREAD_H_
+
+#include <linux/sched.h>
+
+#include <sys/unistd.h>
+#include <sys/kthread.h>
+
+struct kthr_wrap {
+	int (*func)(void *);
+	void *arg;
+};
+
+#define	kthread_run(fn, data, fmt, ...)	({				\
+	struct thread *__td;						\
+	struct kthr_wrap *w;						\
+									\
+	w = malloc(sizeof(struct kthr_wrap), M_DRMKMALLOC, 0);		\
+	w->func = fn;							\
+	w->arg = data;							\
+									\
+	if (kthread_add(drmkpi_kthread_fn, w, NULL, &__td,		\
+	    RFSTOPPED, 0, fmt, ## __VA_ARGS__)) {			\
+		__td = NULL;						\
+		free(w, M_DRMKMALLOC);					\
+	} else								\
+		__td = drmkpi_kthread_setup_and_run(__td);		\
+	__td;								\
+})
+
+int drmkpi_kthread_stop(struct thread *);
+bool drmkpi_kthread_should_stop_task(struct thread *td);
+bool drmkpi_kthread_should_stop(void);
+int drmkpi_kthread_park(struct thread *);
+void drmkpi_kthread_parkme(void);
+bool drmkpi_kthread_should_park(void);
+void drmkpi_kthread_unpark(struct thread *);
+void drmkpi_kthread_fn(void *);
+struct thread *drmkpi_kthread_setup_and_run(struct thread *);
+
+#define	kthread_stop(task)		drmkpi_kthread_stop(task)
+#define	kthread_should_stop()		drmkpi_kthread_should_stop()
+#define	kthread_should_stop_task(task)	drmkpi_kthread_should_stop_task(task)
+#define	kthread_park(task)		drmkpi_kthread_park(task)
+#define	kthread_parkme()		drmkpi_kthread_parkme()
+#define	kthread_should_park()		drmkpi_kthread_should_park()
+#define	kthread_unpark(task)		drmkpi_kthread_unpark(task)
+
+#endif /* _LINUX_KTHREAD_H_ */


### PR DESCRIPTION
drmkpi implemented using no task_struct.
Works fine with DRM scheduler and panfrost