### PR TITLE
Fix lockups during glmark2

### DIFF
--- a/core/drm_syncobj.c
+++ b/core/drm_syncobj.c
@@ -1004,10 +1004,10 @@ static void syncobj_wait_fence_func(struct dma_fence *fence,
 #ifdef __FreeBSD__
 	sleepq_lock(wait->task);
 	*wait->signalledp = true;
-	sleepq_release(wait->task);
-#endif
-
+	wake_up_process_locked(wait->task);
+#else
 	wake_up_process(wait->task);
+#endif
 }
 
 static void syncobj_wait_syncobj_func(struct drm_syncobj *syncobj,
@@ -1028,7 +1028,13 @@ static void syncobj_wait_syncobj_func(struct drm_syncobj *syncobj,
 		wait->fence = fence;
 	}
 
+#ifdef __FreeBSD__
+	sleepq_lock(wait->task);
+	*wait->signalledp = true;
+	wake_up_process_locked(wait->task);
+#else
 	wake_up_process(wait->task);
+#endif
 	list_del_init(&wait->node);
 }
 

--- a/drmkpi/drmcompat_schedule.c
+++ b/drmkpi/drmcompat_schedule.c
@@ -79,17 +79,15 @@ drmcompat_add_to_sleepqueue(void *wchan, struct thread *task,
 	return (ret);
 }
 
-static int
-wake_up_task(struct thread *task, unsigned int state)
+void
+drmcompat_wake_up_task_locked(struct thread *task)
 {
 	int wakeup_swapper;
 
-	sleepq_lock(task);
 	wakeup_swapper = sleepq_signal(task, SLEEPQ_SLEEP, 0, 0);
 	sleepq_release(task);
 	if (wakeup_swapper)
 		kick_proc0();
-	return (1);
 }
 
 static int
@@ -259,11 +257,4 @@ drmcompat_schedule_timeout_interruptible(int timeout)
 	else if (remainder > timeout)
 		remainder = timeout;
 	return (remainder);
-}
-
-bool
-drmcompat_wake_up_state(struct thread *task, unsigned int state)
-{
-
-	return (wake_up_task(task, state) != 0);
 }

--- a/drmkpi/include/drmcompat/wait.h
+++ b/drmkpi/include/drmcompat/wait.h
@@ -72,6 +72,6 @@ int drmcompat_wait_event_common(wait_queue_head_t *, wait_queue_entry_t *, int,
 void drmcompat_prepare_to_wait(wait_queue_head_t *, wait_queue_entry_t *, int);
 void drmcompat_finish_wait(wait_queue_head_t *, wait_queue_entry_t *);
 
-bool drmcompat_wake_up_state(struct thread *, unsigned int);
+void drmcompat_wake_up_task_locked(struct thread *task);
 
 #endif	/* __DRMCOMPAT_WAIT_H__ */

--- a/drmkpi/include/linux/wait.h
+++ b/drmkpi/include/linux/wait.h
@@ -165,7 +165,6 @@
  * schedule() will require special treatment.
  */
 
-#define	wake_up_process(task)		drmcompat_wake_up_state(task, TASK_NORMAL)
-#define	wake_up_state(task, state)	drmcompat_wake_up_state(task, state)
+#define	wake_up_process_locked(task)	drmcompat_wake_up_task_locked(task)
 
 #endif /* __DRMCOMPAT_LINUX_WAIT_H__ */


### PR DESCRIPTION
Set signalledp flag in syncobj_wait_syncobj_func() before signalling the task.
This fixes lockups on morello during glmark2