### PR TITLE
drm_os_freebsd: Fix drm_fstub_ioctl return value sign

### DIFF
--- a/freebsd/drm_os_freebsd.c
+++ b/freebsd/drm_os_freebsd.c
@@ -267,7 +267,7 @@ drm_fstub_ioctl(struct file *file, u_long cmd, void *data, struct ucred *cred,
 		goto out_release;
 	}
 
-	rv = fops->unlocked_ioctl(file, cmd, (unsigned long)data);
+	rv = -fops->unlocked_ioctl(file, cmd, (unsigned long)data);
 
 	dev_relthread(cdev, ref);
 	return (rv);


### PR DESCRIPTION
This function is at the FreeBSD/Linux boundary, with unlocked_ioctl conforming to Linux's return value conventions, i.e. errors are negative, and drm_fstub_ioctl conforming to FreeBSD's, i.e. errors are positive. Thus, negate the return value here to translate between the two, otherwise userspace will see negated errno values that don't match any known value; in particular, libdrm's drmIsMaster will erroneously always return true, which breaks KWin leasing a DRM fd to Xwayland.

This also matches what linuxkpi does, as used by drm-kmod.